### PR TITLE
Fix the header covering background

### DIFF
--- a/public/app/sass/layout/_header.scss
+++ b/public/app/sass/layout/_header.scss
@@ -6,9 +6,9 @@
 .layout-header {
 	@extend %reset-margins;
 	box-shadow: inset 0 -1rem 0 0 rgba(black, 0.25);
-	background: white image-url('header.jpg') fixed no-repeat;
+	background: #050409 image-url('header.jpg') fixed no-repeat;
 	background-size: cover;
-	background-position: center -500px;
+	background-position: center center;
 	padding: 11rem 0;
 	text-align: center;
 	transition: padding 0.3s;


### PR DESCRIPTION
Hi!

The actual rocketeer header background looks like this on tiny screen (< 15''):
![rocketeer-actual](https://cloud.githubusercontent.com/assets/415891/6766387/33d913ec-d005-11e4-956b-2d42b5129aa9.png)

I made an ajustment to be sure that the header background is covering:
![rocketeer-covering](https://cloud.githubusercontent.com/assets/415891/6766392/49e4b326-d005-11e4-89db-ff333c1a30a4.png)

I also improved the color fallback, that allow the user to read the main title when the website is loading:
![rocketeer-loading](https://cloud.githubusercontent.com/assets/415891/6766397/61755a68-d005-11e4-8b02-2e2307aa2c30.png)

Cheers,
Thomas.
